### PR TITLE
Re-upload 2016's videos via 未踏ジュニア公式チャンネル

### DIFF
--- a/2016.html
+++ b/2016.html
@@ -80,7 +80,7 @@
                         <div class="row">
                             <div class="col-lg-4 col-lg-offset-1 col-md-4">
                                 <div class="youtube">
-                                    <iframe width="560" height="315" src="https://www.youtube.com/embed/kkR1XsExQR4?rel=0" frameborder="0" allowfullscreen></iframe>   
+				    <iframe width="560" height="315" src="https://www.youtube.com/embed/APUTGg6g0hA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 </div>
                             </div>
                             <div class="col-lg-6 col-md-6">
@@ -113,7 +113,7 @@
                         <div class="row">
                             <div class="col-lg-4 col-lg-offset-1 col-md-4">
                                 <div class="youtube">
-                                    <iframe width="560" height="315" src="https://www.youtube.com/embed/EQDsuKpgcSk?rel=0" frameborder="0" allowfullscreen></iframe>
+				    <iframe width="560" height="315" src="https://www.youtube.com/embed/sdrPyfNJx-4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                 </div>
                             </div>
                             <div class="col-lg-6 col-md-6">
@@ -143,8 +143,8 @@
                         <div class="row">
                             <div class="col-lg-4 col-lg-offset-1 col-md-4">
                                 <div class="youtube">
-                                    <iframe width="560" height="315" src="https://www.youtube.com/embed/lGBrhjgm6Ew?rel=0" frameborder="0" allowfullscreen></iframe>
-                                </div>
+				    <iframe width="560" height="315" src="https://www.youtube.com/embed/V3SVBM47jOs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+				</div>
                             </div>
                             <div class="col-lg-6 col-md-6">
                                 <h5>概要</h5>


### PR DESCRIPTION
Fix #25 cc/ @ukkari 

未踏ジュニア公式チャンネルから2016年度の動画を再アップロードして差し替えました! 📺 🆕 ✨ 
ついでに音量を [Auphonic Leveler](https://auphonic.com/leveler) で調整、プレゼン動画の一部画面拡大などもやっています ;)

現在は限定公開となっていますが、 @ukkari さんの個人アカウントにある当該動画が整理されたら、限定公開→一般公開に切り替えます 🔧 💨 